### PR TITLE
Remove whisker entries and make sure cloud-nucleo.jar doesn't contain scripts

### DIFF
--- a/centos7/cosmic.spec
+++ b/centos7/cosmic.spec
@@ -117,8 +117,11 @@ install -D %{_sourcecodefolder}/cosmic-core/agent/target/transformed/cloud-ssh $
 install -D %{_sourcecodefolder}/cosmic-core/agent/target/transformed/cosmic-agent-profile.sh ${RPM_BUILD_ROOT}%{_sysconfdir}/profile.d/%{name}-agent-profile.sh
 install -D %{_sourcecodefolder}/cosmic-core/agent/target/transformed/cosmic-agent.logrotate ${RPM_BUILD_ROOT}%{_sysconfdir}/logrotate.d/%{name}-agent
 install -D %{_sourcecodefolder}/cosmic-plugin-hypervisor-kvm/target/cloud-plugin-hypervisor-kvm-%{_maventag}.jar ${RPM_BUILD_ROOT}%{_datadir}/%name-agent/lib/cloud-plugin-hypervisor-kvm-%{_maventag}.jar
-cp         %{_sourcecodefolder}/cosmic-plugin-hypervisor-kvm/target/dependencies/*  ${RPM_BUILD_ROOT}%{_datadir}/%{name}-agent/lib
 
+cp      %{_sourcecodefolder}/cosmic-plugin-hypervisor-kvm/target/dependencies/*  ${RPM_BUILD_ROOT}%{_datadir}/%{name}-agent/lib
+
+# No scripts should be present in the Agent cloud-nucleo jar; otherwise we might face classpath order problems.
+zip    -d ${RPM_BUILD_ROOT}%{_datadir}/%{name}-agent/lib/cloud-nucleo-%{_maventag}.jar scripts*
 
 #License files from whisker
 install -D %{_sourcecodefolder}/cosmic-core/tools/whisker/NOTICE ${RPM_BUILD_ROOT}%{_defaultdocdir}/%{name}-common-%{version}/NOTICE


### PR DESCRIPTION
The scripts are loaded from the file system. Having them in the JAR file will confuse the classloader and try to get the script files from the wrong location. It breaks the Agent.

This PR makes sure that the scripts are deleted from the JAR before copying them into cosmic-agent/lib directory.
