### PR TITLE
Depend on socat

### DIFF
--- a/centos7/cosmic.spec
+++ b/centos7/cosmic.spec
@@ -62,6 +62,7 @@ Requires: perl
 Requires: libvirt-python
 Requires: qemu-img
 Requires: qemu-kvm
+Requires: socat
 Provides: cloud-agent
 Group: System Environment/Libraries
 


### PR DESCRIPTION
Used in combination with this PR:
https://github.com/MissionCriticalCloud/cosmic-core/pull/105

Package builds fine and contains dependency:

```
+ exit 0
RPM Build Done
```

```
[root@kvm1 ~]# rpm -qpR cosmic-agent-5.0.0.1-SNAPSHOT.el7.centos.x86_64.rpm | grep socat
socat
```
