### PR TITLE
Add environment var to enable remote debugging

### DIFF
--- a/systemd/cosmic-agent.service
+++ b/systemd/cosmic-agent.service
@@ -13,7 +13,7 @@ Environment=JAVA_CLASS=com.cloud.agent.AgentShell
 ExecStart=/bin/sh -ec '\
     export ACP=`ls /usr/share/cosmic-agent/lib/*.jar /usr/share/cosmic-agent/plugins/*.jar 2>/dev/null|tr "\\n" ":"`; \
     export CLASSPATH="$ACP:/etc/cosmic/agent:/usr/share/cosmic-common/scripts"; \
-    ${JAVA_HOME}/bin/java -Xms${JAVA_HEAP_INITIAL} -Xmx${JAVA_HEAP_MAX} -cp "$CLASSPATH" $JAVA_CLASS'
+    ${JAVA_HOME}/bin/java -Xms${JAVA_HEAP_INITIAL} -Xmx${JAVA_HEAP_MAX} ${JAVA_REMOTE_DEBUG} -cp "$CLASSPATH" $JAVA_CLASS'
 Restart=always
 RestartSec=10s
 


### PR DESCRIPTION
The environment var `${JAVA_REMOTE_DEBUG}` is empty by default so no remote debugging.

Enabling it, is as easy as dropping a file in the `cosmic-agent.service.d` folder:

```
mkdir -p /etc/systemd/system/multi-user.target.wants/cosmic-agent.service.d/
printf "[Service]\nEnvironment=JAVA_REMOTE_DEBUG=-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8000" > /etc/systemd/system/multi-user.target.wants/cosmic-agent.service.d/debug.conf
systemctl daemon-reload
systemctl restart cosmic-agent
```

In our CI we can turn in on by default, in generic packaging it is still off.
